### PR TITLE
Use relative paths in example config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.project
 /target/
+/output/
 
 /src/main/resources/config.json
 /src/main/resources/log4j2-test.properties

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 * Edit the configuration file to set appropriate input source and output destination.
 * Within `InputService`, change the `source` attribute to point either to a single file of MARCXML, or to a directory containing MARCXML files.
   * Each input file must have a filename extension of `.xml`
-  * Sample minimal record is in sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.xml.
+  * Sample minimal record is in `sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.xml`.
 * Within `OutputService`, change the `destination` attribute to point to your desired output directory. 
   * _You **must** create this directory before running the program._
 

--- a/src/main/resources/example.config.json
+++ b/src/main/resources/example.config.json
@@ -2,12 +2,12 @@
   "localNamespace": "http://data.ld4l.org/cornell/",
   "InputService": {
     "class": "org.ld4l.bib2lod.io.FileInputService",
-    "source": "/Users/user/projects/bib2lod/sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.xml",
+    "source": "sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.xml",
     "extension": "xml"
   }, 
   "OutputService": {
     "class": "org.ld4l.bib2lod.io.FileOutputService",
-    "destination": "/Users/user/projects/bib2lod/output/",
+    "destination": "output/",
     "format": "N-TRIPLE"
   },
   "UriService": [


### PR DESCRIPTION
After changing to `src/main/resources/example.config.json` to use local paths one can install and run with as little as:

```
git clone git@github.com:ld4l-labs/bib2lod.git
cd bib2lod
mvn install
mkdir output
java -jar target/bib2lod.jar -c src/main/resources/example.config.json
more output/102063.min.nt
```

(Might also be worth putting something like the block above as a "Quick Start" in the README but I don't want to mess up the current structure.)