### PR TITLE
Fix example so that it matches converter output

### DIFF
--- a/sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.draft-expanded.ttl
+++ b/sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.draft-expanded.ttl
@@ -1,0 +1,140 @@
+###########################################################
+#####
+##### CURRENT VERSION
+#####
+###########################################################
+
+
+@prefix bf: <http://id.loc.gov/ontologies/bibframe/> .
+@prefix cornell: <http://data.ld4l.org/cornell/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ld4l: <http://bib.ld4l.org/ontology/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+    
+cornell:work1 a bf:Work;    
+
+    bf:hasInstance cornell:inst1 ;
+    
+    bf:title [
+        a bf:Title ;
+        rdfs:label "Clinical cardiopulmonary physiology." ;
+        dcterms:hasPart [
+            a ld4l:MainTitleElement ;
+            rdfs:label "Clinical cardiopulmonary physiology." 
+        ] ;
+    ] 
+. 
+
+cornell:inst1 a bf:Instance ; 
+
+    bf:hasItem cornell:item1 ; 
+
+    bf:title [
+        a bf:Title ;
+        rdfs:label "Clinical cardiopulmonary physiology." ;
+        dcterms:hasPart [
+            a ld4l:MainTitleElement ;
+            rdfs:label "Clinical cardiopulmonary physiology."
+        ] ;        
+    ] ; 
+    
+    bf:responsibilityStatement "Sponsored by the American College of Chest Physicians. Editorial board: Burgess L. Gordon, chairman, editor-in-chief, Albert H. Andrews [and others]" ;
+. 
+
+cornell:item1 a bf:Item .
+
+
+
+###########################################################
+#####
+##### MORE COMPLETE VERSION (needs further investigation)
+#####
+###########################################################
+
+
+@prefix bf: <http://id.loc.gov/ontologies/bibframe/> .
+@prefix cornell: <http://data.ld4l.org/cornell/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ld4l: <http://bib.ld4l.org/ontology/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+    
+cornell:work1 a bf:Work, bf:Text ;    
+
+    bf:hasInstance cornell:inst1 ;
+    
+    bf:title [
+        a bf:Title ;
+        rdfs:label "Clinical cardiopulmonary physiology." ;
+        dcterms:hasPart [
+            a ld4l:MainTitleElement ;
+            rdfs:label "Clinical cardiopulmonary physiology." 
+        ] ;
+    ] ; 
+    
+    dcterms:language <http://id.loc.gov/vocabulary/languages/eng> ;
+    
+    bf:adminMetadata [
+        a bf:AdminMetadata ;
+        bf:identifiedBy [ # Identifies Instance or AdminMetadata?
+            a bf:Local ;
+            rdf:value "102063" ;
+            ld4l:hasSource </http://uri/to/nnc> # URI to NNC
+        ] ;
+        bf:status [
+            a bf:Status ;
+            bf:code "c"
+        ] ;
+        bf:encodingLevel [ # Property doesn't exist
+           a bf:EncodingLevel ; # Class doesn't exist
+           bf:code "1 "
+        ] ;
+        bf:creationDate "1986-05-06"
+    ]     
+. 
+
+
+cornell:inst1 a bf:Instance ; 
+
+    bf:hasItem cornell:item1 ; 
+
+    bf:title [
+        a bf:Title ;
+        rdfs:label "Clinical cardiopulmonary physiology." ;
+        dcterms:hasPart [
+            a ld4l:MainTitleElement ;
+            rdfs:label "Clinical cardiopulmonary physiology."
+        ] ;        
+    ] ; 
+    
+    bf:responsibilityStatement "Sponsored by the American College of Chest Physicians. Editorial board: Burgess L. Gordon, chairman, editor-in-chief, Albert H. Andrews [and others]" ;
+    
+    bf:issuance [
+        a bf:Issuance ;
+        # Should not code MARC into the RDF. Possibly can make an exception for AdminMetadata, but not other resources.
+        bf:code "m" 
+    ] ;
+    
+    ld4l:hasActivity [
+        a ld4l:PublicationActivity ;
+        dcterms:date "1957" ;
+        ld4l:atLocation <http://id.loc.gov/vocabulary/countries/nyu>
+    ] ; 
+    
+    bf:illustrativeContent <http://id.loc.gov/authorities/genreForms/gf2014026048> ;
+    
+    bf:adminMetadata [
+        a bf:AdminMetadata ;
+        bf:identifiedBy [ # Identifies Instance or AdminMetadata?
+            a bf:Local ;
+            rdf:value "102063" ;
+            ld4l:hasSource </http://uri/to/nnc> # URI to NNC
+        ]  
+    ]    
+. 
+
+
+cornell:item1 a bf:Item .

--- a/sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.ttl
+++ b/sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.ttl
@@ -1,9 +1,4 @@
-###########################################################
-#####
-##### CURRENT VERSION
-#####
-###########################################################
-
+##### EXPECTED OUTPUT FROM CONVERSION OF 102063.min.xml, NOT NECESSARILY "CORRECT"
 
 @prefix bf: <http://id.loc.gov/ontologies/bibframe/> .
 @prefix cornell: <http://data.ld4l.org/cornell/> .
@@ -11,130 +6,44 @@
 @prefix ld4l: <http://bib.ld4l.org/ontology/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-
+@prefix vivo: <http://vivoweb.org/ontology/core#> .
     
 cornell:work1 a bf:Work;    
 
-    bf:hasInstance cornell:inst1 ;
-    
-    bf:title [
+    ld4l:hasPreferredTitle [
         a bf:Title ;
         rdfs:label "Clinical cardiopulmonary physiology." ;
         dcterms:hasPart [
             a ld4l:MainTitleElement ;
-            rdfs:label "Clinical cardiopulmonary physiology." 
+            rdfs:label "Clinical cardiopulmonary physiology." ;
+	    vivo:rank 10
         ] ;
     ] 
 . 
 
-cornell:inst1 a bf:Instance ; 
+cornell:inst1 a bf:Instance ;
 
+    bf:instanceOf cornell:work1 ;
+    
     bf:hasItem cornell:item1 ; 
 
-    bf:title [
-        a bf:Title ;
-        rdfs:label "Clinical cardiopulmonary physiology." ;
-        dcterms:hasPart [
-            a ld4l:MainTitleElement ;
-            rdfs:label "Clinical cardiopulmonary physiology."
-        ] ;        
-    ] ; 
-    
-    bf:responsibilityStatement "Sponsored by the American College of Chest Physicians. Editorial board: Burgess L. Gordon, chairman, editor-in-chief, Albert H. Andrews [and others]" ;
-. 
-
-cornell:item1 a bf:Item .
-
-
-
-###########################################################
-#####
-##### MORE COMPLETE VERSION (needs further investigation)
-#####
-###########################################################
-
-
-@prefix bf: <http://id.loc.gov/ontologies/bibframe/> .
-@prefix cornell: <http://data.ld4l.org/cornell/> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix ld4l: <http://bib.ld4l.org/ontology/> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-
-    
-cornell:work1 a bf:Work, bf:Text ;    
-
-    bf:hasInstance cornell:inst1 ;
-    
-    bf:title [
-        a bf:Title ;
-        rdfs:label "Clinical cardiopulmonary physiology." ;
-        dcterms:hasPart [
-            a ld4l:MainTitleElement ;
-            rdfs:label "Clinical cardiopulmonary physiology." 
-        ] ;
-    ] ; 
-    
-    dcterms:language <http://id.loc.gov/vocabulary/languages/eng> ;
-    
-    bf:adminMetadata [
-        a bf:AdminMetadata ;
-        bf:identifiedBy [ # Identifies Instance or AdminMetadata?
-            a bf:Local ;
-            rdf:value "102063" ;
-            ld4l:hasSource </http://uri/to/nnc> # URI to NNC
-        ] ;
-        bf:status [
-            a bf:Status ;
-            bf:code "c"
-        ] ;
-        bf:encodingLevel [ # Property doesn't exist
-           a bf:EncodingLevel ; # Class doesn't exist
-           bf:code "1 "
-        ] ;
-        bf:creationDate "1986-05-06"
-    ]     
-. 
-
-
-cornell:inst1 a bf:Instance ; 
-
-    bf:hasItem cornell:item1 ; 
-
-    bf:title [
-        a bf:Title ;
-        rdfs:label "Clinical cardiopulmonary physiology." ;
-        dcterms:hasPart [
-            a ld4l:MainTitleElement ;
-            rdfs:label "Clinical cardiopulmonary physiology."
-        ] ;        
-    ] ; 
-    
-    bf:responsibilityStatement "Sponsored by the American College of Chest Physicians. Editorial board: Burgess L. Gordon, chairman, editor-in-chief, Albert H. Andrews [and others]" ;
-    
-    bf:issuance [
-        a bf:Issuance ;
-        # Should not code MARC into the RDF. Possibly can make an exception for AdminMetadata, but not other resources.
-        bf:code "m" 
+    bf:identifiedBy [
+        a bf:Identifier ;
+        a bf:Local ; 
+        rdf:value "102063"
     ] ;
-    
-    ld4l:hasActivity [
-        a ld4l:PublicationActivity ;
-        dcterms:date "1957" ;
-        ld4l:atLocation <http://id.loc.gov/vocabulary/countries/nyu>
+
+    ld4l:hasPreferredTitle [
+        a bf:Title ;
+        rdfs:label "Clinical cardiopulmonary physiology." ;
+        dcterms:hasPart [
+            a ld4l:MainTitleElement ;
+            rdfs:label "Clinical cardiopulmonary physiology." ;
+	    vivo:rank 10
+        ] ;        
     ] ; 
     
-    bf:illustrativeContent <http://id.loc.gov/authorities/genreForms/gf2014026048> ;
-    
-    bf:adminMetadata [
-        a bf:AdminMetadata ;
-        bf:identifiedBy [ # Identifies Instance or AdminMetadata?
-            a bf:Local ;
-            rdf:value "102063" ;
-            ld4l:hasSource </http://uri/to/nnc> # URI to NNC
-        ]  
-    ]    
+    bf:responsibilityStatement "Sponsored by the American College of Chest Physicians.  Editorial board: Burgess L. Gordon, chairman, editor-in-chief, Albert H. Andrews [and others]" ;
 . 
-
 
 cornell:item1 a bf:Item .


### PR DESCRIPTION
The current `sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.ttl` does not match the output of conversion of `sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.xml`. This PR

  1. makes `102063.min.ttl` match converter output (modulo local data and bnodes)
  2. splits off the second, expanded example into `102063.draft-expanded.ttl`

If output of conversion is written to `output/102063.min.nt` then we get:

```
> rdfdiffb.py -s -b 'data.ld4l.org' sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.ttl output/102063.min.nt 
Graphs sample-data/sample-conversions/marcxml-to-ld4l/cornell/102063-min/102063.min.ttl and output/102063.min.nt are isomorphic after bnode substitutions
```