### PR TITLE
Python functional black-box tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@
 /src/main/resources/config.json
 /src/main/resources/log4j2-test.properties
 
-
+# Python tests
+/.cache/
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,23 @@ language: java
 jdk:
   - oraclejdk8
 sudo: false
-script: mvn test
+install:
+  # Install Python via conda so we don't have to use sudo
+  # see https://conda.io/docs/travis.html
+  - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda create -q -n test-environment python=2.7
+  - source activate test-environment
+  - pip install rdiffb pytest
+  - mvn install
+script:
+  - mvn test
+  - py.test
 after_success:
   - mvn clean test jacoco:report coveralls:report
   
@@ -11,4 +27,3 @@ branches:
   only:
   - master
   - develop
- 

--- a/tests_functional/test_bib2lod.py
+++ b/tests_functional/test_bib2lod.py
@@ -1,0 +1,64 @@
+"""Functional tasts for bib2lod Java program."""
+from .testcase_with_tmpdir import TestCase
+import glob
+import io
+import json
+import os.path
+from rdiffb import RDiffB
+import subprocess
+
+
+def run_bib2lod(args):
+    """Run bib2lod with specified args.
+
+    First argument must be the configuration file name.
+    """
+    prefix_args = ['java', '-jar', 'target/bib2lod.jar', '-c']
+    prefix_args.reverse()
+    for arg in prefix_args:
+        args.insert(0, arg)
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+    (out, err) = proc.communicate()
+    return(out)
+
+
+def example_config():
+    """Read example configuration file, return object to modify."""
+    return json.load(open('src/main/resources/example.config.json', 'r'))
+
+
+class TestBib2lod(TestCase):
+    """Some bib2lod tests..."""
+
+    def write_config(self, config, filename="config.json"):
+        """Write test config to tmpdir, return filepath."""
+        filepath = os.path.join(self.tmpdir, filename)
+        with open(filepath, 'w') as fh:
+            json.dump(config, fh)
+        return(filepath)
+
+    def test01_config_errors(self):
+        """Test simple errors attempting to run bib2lod."""
+        out = run_bib2lod([])
+        self.assertIn(b"You must provide a value after '-c'", out)
+        out = run_bib2lod(['DOES_NOT_EXIST'])
+        self.assertIn(b"Configuration file does not exist", out)
+        out = run_bib2lod(['tests_functional/testdata/bad1.json'])
+        self.assertIn(b"invalid JSON", out)
+
+    def test02_cornell_ld4l_conversion(self):
+        """Test Cornel LD4L conversions based on sample configuration file."""
+        indirs = 'sample-data/sample-conversions/marcxml-to-ld4l/cornell'
+        outdir = self.tmpdir
+        for indir in glob.glob(os.path.join(indirs, '*')):
+            # FIXME - should look for *.xml in each dir and then build tests on that
+            src = os.path.join(indir, '102063.min.xml')
+            ref = os.path.join(indir, '102063.min.ttl')
+            dst = os.path.join(outdir, '102063.min.nt')
+            config = example_config()
+            config['InputService']['source'] = src
+            config['OutputService']['destination'] = outdir
+            config_filepath = self.write_config(config)
+            out = run_bib2lod([config_filepath])
+            self.assertTrue(os.path.exists(dst))
+            self.assertEqual(RDiffB(['data.ld4l.org/cornell']).compare_files([ref, dst]), 0)

--- a/tests_functional/testcase_with_tmpdir.py
+++ b/tests_functional/testcase_with_tmpdir.py
@@ -1,0 +1,45 @@
+"""Extension of unittest.TestCase to create a temp directory tmpdir."""
+import sys
+import os.path
+import unittest
+import tempfile
+import shutil
+
+
+class TestCase(unittest.TestCase):
+    """Adds setUpClass an tearDownClass that create and destroy tmpdir."""
+
+    _tmpdir = None
+
+    @classmethod
+    def setUpClass(cls):
+        # Create tmp dir to write to and check
+        cls._tmpdir = tempfile.mkdtemp()
+        if (not os.path.isdir(cls._tmpdir)):
+            raise Exception("Failed to create tempdir to use for dump tests")
+        try:
+            cls.extraSetUpClass()
+        except:
+            pass
+
+    @classmethod
+    def tearDownClass(cls):
+        # Cleanup
+        if (not os.path.isdir(cls._tmpdir)):
+            raise Exception("Ooops, no tempdir (%s) to clean up?" % (tmpdir))
+        shutil.rmtree(cls._tmpdir)
+        try:
+            cls.extraTearUpClass()
+        except:
+            pass
+
+    @property
+    def tmpdir(self):
+        # read-only access to _tmpdir, just in case... The rmtree scares me
+        #
+        # FIXME - Hack to work on python2.6 where setUpClass is not called, will
+        # FIXME - not have proper tidy as tearDownClass will not be called.
+        # FIXME - Remove when 2.6 no longer supported
+        if (not self._tmpdir and sys.version_info < (2, 7)):
+            self.setUpClass()
+        return(self._tmpdir)

--- a/tests_functional/testdata/bad1.json
+++ b/tests_functional/testdata/bad1.json
@@ -1,0 +1,1 @@
+this is not valid JSON


### PR DESCRIPTION
Here is a first stab at some tests of the converter as a script. The tests include a few error cases (e.g. running without -c config) and a RDF diff based test of conversion of the minimal record (based on #28 fix). 

Should discuss how to do such tests in a maintainable way before merging. If we agree on a structure for samples and expected output the test can be made to pick test cases up automagically.